### PR TITLE
Generate service files (fix #24)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.v]
+indent_style = tab
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.v linguist-language=V text=auto eol=lf
+*.vv linguist-language=V text=auto eol=lf
+*.vsh linguist-language=V text=auto eol=lf
+**/v.mod linguist-language=V text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Binaries for programs and plugins
+main
+c2v
+*.exe
+*.exe~
+*.so
+*.dylib
+*.dll
+vls.log

--- a/v.mod
+++ b/v.mod
@@ -1,7 +1,7 @@
 Module {
 	name: 'c2v'
-	description: ''
-	version: ''
-	license: ''
+	description: 'Tool for translation/wrapper generation from C to V'
+	version: '0.1.0'
+	license: 'GPLv3'
 	dependencies: []
 }

--- a/v.mod
+++ b/v.mod
@@ -1,7 +1,7 @@
 Module {
 	name: 'c2v'
 	description: 'Tool for translation/wrapper generation from C to V'
-	version: '0.1.0'
+	version: '0.3.1'
 	license: 'GPLv3'
 	dependencies: []
 }

--- a/v.mod
+++ b/v.mod
@@ -1,0 +1,7 @@
+Module {
+	name: 'c2v'
+	description: ''
+	version: ''
+	license: ''
+	dependencies: []
+}


### PR DESCRIPTION
Reasons:
- generate service files for git/GitHub to have an excellent maintained repo and suitable "languages" on the GitHub page
- create a mod file