### PR TITLE
Add clang v14 to lookup versions list

### DIFF
--- a/c2v.v
+++ b/c2v.v
@@ -89,7 +89,7 @@ mut:
 }
 
 fn find_clang_in_path() string {
-	clangs := ['clang-13', 'clang-12', 'clang-11', 'clang-10', 'clang']
+	clangs := ['clang-14', 'clang-13', 'clang-12', 'clang-11', 'clang-10', 'clang']
 	for clang in clangs {
 		os.find_abs_path_of_executable(clang) or { continue }
 		return clang


### PR DESCRIPTION
I have clang 14, I would like to stop having to manually add this version to my local copy of c2v.