### PR TITLE
fix bug that uint64_t will be converted to i64

### DIFF
--- a/c2v.v
+++ b/c2v.v
@@ -541,11 +541,6 @@ fn convert_type(typ_ string) Type {
 		vprintln('\nconvert_type("$typ")')
 	}
 
-	if typ.contains('int64') && !typ.contains(' ') {
-		return Type{
-			name: 'i64'
-		}
-	}
 	if typ.contains('__va_list_tag *') {
 		return Type{
 			name: 'va_list'

--- a/tests/7.api_types.out
+++ b/tests/7.api_types.out
@@ -64,12 +64,12 @@ struct Tm_str_t {
 }
 
 struct Tm_clock_o {
-	opaque i64
+	opaque u64
 }
 
 struct Tm_uuid_t {
-	a i64
-	b i64
+	a u64
+	b u64
 }
 
 struct Tm_color_srgb_t {
@@ -80,14 +80,14 @@ struct Tm_color_srgb_t {
 }
 
 struct Tm_tt_type_t {
-	u64 i64
+	u64 u64
 }
 
 struct Tm_tt_id_t {
 }
 
 struct Tm_tt_undo_scope_t {
-	u64 i64
+	u64 u64
 }
 
 struct Tm_version_t {
@@ -97,5 +97,5 @@ struct Tm_version_t {
 }
 
 struct Tm_strhash_t {
-	u64 i64
+	u64 u64
 }


### PR DESCRIPTION
```c
typedef struct tm_clock_o
{
    uint64_t opaque;
} tm_clock_o;
```

old:
```v
struct Tm_clock_o {
	opaque i64
}
```

new:
```v
struct Tm_clock_o {
	opaque u64
}
```