### PR TITLE
fix capitalization for u16 and friends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ c2v
 *.dylib
 *.dll
 vls.log
+tests/run_tests

--- a/c2v.v
+++ b/c2v.v
@@ -881,7 +881,9 @@ fn (mut c C2V) typedef_decl(node &Node) {
 		if cgen_alias.starts_with('_') {
 			cgen_alias = trim_underscores(typ)
 		}
-		if typ !in ['int', 'i8', 'i16', 'u8', 'i64', 'u32', 'f64'] && !typ.starts_with('fn (') {
+		if
+			typ !in ['int', 'i8', 'i16', 'i64', 'u8', 'u16', 'u32', 'u64', 'f32', 'f64', 'usize', 'isize', 'bool', 'void', 'voidptr']
+			&& !typ.starts_with('fn (') {
 			// TODO handle this better
 			cgen_alias = cgen_alias.capitalize()
 		}

--- a/tests/6.types.c
+++ b/tests/6.types.c
@@ -1,7 +1,23 @@
 #include <stdio.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+// standard types should be lower-cased
+typedef unsigned short ushort;
+typedef float f32;
+typedef size_t size_t;
+typedef void *null;
+typedef size_t usize;
+typedef ptrdiff_t isize;
+typedef bool maybe;
+
+// not sure how this is supposed to work
+typedef intptr_t iptr;
 
 int main()
 {
     void *pointers[8];
+
     return 0;
 }

--- a/tests/6.types.c
+++ b/tests/6.types.c
@@ -1,19 +1,20 @@
 #include <stdio.h>
-#include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
 
 // standard types should be lower-cased
-typedef unsigned short ushort;
-typedef float f32;
-typedef size_t size_t;
-typedef void *null;
-typedef size_t usize;
-typedef ptrdiff_t isize;
-typedef bool maybe;
+typedef unsigned short v_u16;
+typedef float v_f32;
+typedef size_t v_usize;
+typedef void *v_voidptr;
+typedef bool v_bool;
+
+// disabled for macOS/Linux compatibility
+//#include <stddef.h>
+//typedef ptrdiff_t v_isize;
 
 // not sure how this is supposed to work
-typedef intptr_t iptr;
+typedef intptr_t c_intptr_t;
 
 int main()
 {

--- a/tests/6.types.out
+++ b/tests/6.types.out
@@ -1,14 +1,12 @@
 [translated]
 module main
 
-type Wchar_t = int
-type Ushort = u16
-type F32 = f32
-type Null = voidptr
-type Usize = usize
-type Isize = isize
-type Maybe = bool
-type Iptr = C.intptr_t
+type V_u16 = u16
+type V_f32 = f32
+type V_usize = usize
+type V_voidptr = voidptr
+type V_bool = bool
+type C_intptr_t = C.intptr_t
 
 fn main() {
 	pointers := [8]voidptr{}

--- a/tests/6.types.out
+++ b/tests/6.types.out
@@ -1,6 +1,15 @@
 [translated]
 module main
 
+type Wchar_t = int
+type Ushort = u16
+type F32 = f32
+type Null = voidptr
+type Usize = usize
+type Isize = isize
+type Maybe = bool
+type Iptr = C.intptr_t
+
 fn main() {
 	pointers := [8]voidptr{}
 	return


### PR DESCRIPTION
This is a small fix to avoid capitalization u16, usize, isize, f32, bool and voidptr.

I also added `C.intptr_t` to the types test, but I don't see how this is supposed to work.