### PR TITLE
Remove c attribute for wrapper methods

### DIFF
--- a/src/c2v.v
+++ b/src/c2v.v
@@ -462,7 +462,9 @@ fn (mut c C2V) fn_decl(node &Node, gen_types string) {
 			c.genln('fn C.${c_name}($str_args) $typ\n')
 		}
 		v_name := name.to_lower()
-
+		if v_name != c_name {
+			c.genln("[c:'$c_name']")
+		}
 		if c.is_wrapper {
 			// strip the "modulename__" from the start of the function
 			stripped_name := v_name.replace(c.wrapper_module_name + '_', '')

--- a/src/c2v.v
+++ b/src/c2v.v
@@ -462,9 +462,7 @@ fn (mut c C2V) fn_decl(node &Node, gen_types string) {
 			c.genln('fn C.${c_name}($str_args) $typ\n')
 		}
 		v_name := name.to_lower()
-		if v_name != c_name {
-			c.genln("[c:'$c_name']")
-		}
+
 		if c.is_wrapper {
 			// strip the "modulename__" from the start of the function
 			stripped_name := v_name.replace(c.wrapper_module_name + '_', '')

--- a/tests/8.simple_func_header.out
+++ b/tests/8.simple_func_header.out
@@ -3,7 +3,6 @@ module tests
 
 fn C.testFunc()
 
-[c: 'testFunc']
 pub fn testfunc() {
 	C.testFunc()
 }


### PR DESCRIPTION
Changes were introduced in #63 by @dedesite, but then he notified that attribute generation is not needed (https://github.com/vlang/c2v/pull/63#issuecomment-1243355412)
I just implemented that fix since he probably doesn't have time to do that or something