### PR TITLE
Remove `builtins.v`

### DIFF
--- a/src/builtins.v
+++ b/src/builtins.v
@@ -1,3 +1,0 @@
-module main
-
-const builtins = ''


### PR DESCRIPTION
Seems builtins.v is just a hollow file and contains no logic at all. All builtins logic was placed in the c2v.v file