### PR TITLE
Add fseek and rewind built-in functions

### DIFF
--- a/src/c2v.v
+++ b/src/c2v.v
@@ -18,7 +18,7 @@ const v_keywords = ['go', 'type', 'true', 'false', 'module', 'byte', 'in', 'none
 const builtin_fn_names = ['fopen', 'puts', 'fflush', 'printf', 'memset', 'atoi', 'memcpy', 'remove',
 	'strlen', 'rename', 'stdout', 'stderr', 'stdin', 'ftell', 'fclose', 'fread', 'read', 'perror',
 	'ftruncate', 'FILE', 'strcmp', 'toupper', 'strchr', 'strdup', 'strncasecmp', 'strcasecmp',
-	'isspace', 'strncmp', 'malloc', 'close', 'open', 'lseek', 'fgets', 'write', 'calloc', 'setenv',
+	'isspace', 'strncmp', 'malloc', 'close', 'open', 'lseek', 'fseek', 'fgets', 'rewind', 'write', 'calloc', 'setenv',
 	'gets', 'abs', 'sqrt', 'erfl', 'fprintf', 'snprintf', 'exit', '__stderrp', 'fwrite', 'scanf',
 	'sscanf', 'strrchr', 'strchr', 'div', 'free', 'memcmp', 'memmove', 'vsnprintf', 'rintf', 'rint']
 


### PR DESCRIPTION
This PR adds these two functions.
[fseek](https://man7.org/linux/man-pages/man3/fseek.3.html)
[rewind](https://man7.org/linux/man-pages/man3/rewind.3p.html)