### PR TITLE
Improve CI push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - 'main'
   pull_request:
   schedule:
     - cron: '31 1,12 * * *'


### PR DESCRIPTION
Trigger push jobs only on push to main branch, not in PR (this provides to double run for the same jobs)