### PR TITLE
Improve CI push trigger

### DIFF
--- a/.github/workflows/doom_gfx_regressions.yml
+++ b/.github/workflows/doom_gfx_regressions.yml
@@ -2,6 +2,8 @@ name: Graphics CI
 
 on:
   push:
+    branches:
+      - 'main'
     paths-ignore:
       - "**.md"
   pull_request:


### PR DESCRIPTION
Trigger push jobs only on push to main branch, not in PR (this provides to double run for the same jobs)