### PR TITLE
fix switch with default stmt before case stmt

### DIFF
--- a/tests/13.switch.c
+++ b/tests/13.switch.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+
+const int a = 0;
+
+void main() 
+{ 
+    switch(a)
+    {
+    default:
+        printf("foo\n");
+        break;
+    case 0:
+        printf("bar\n");
+        break;
+    }
+
+
+    switch(a)
+    {
+    case 0:
+        printf("bar\n");
+        break;
+    default:
+        printf("foo\n");
+        break;
+    }
+}

--- a/tests/13.switch.out
+++ b/tests/13.switch.out
@@ -1,0 +1,26 @@
+[translated]
+module main
+
+[export: 'a']
+const (
+	a = 0
+)
+
+fn main() {
+	match a {
+		0 /* case comp body kind=CallExpr is_enum=true */ {
+			C.printf(c'bar\n')
+		}
+		else {
+			C.printf(c'foo\n')
+		}
+	}
+	match a {
+		0 /* case comp body kind=CallExpr is_enum=true */ {
+			C.printf(c'bar\n')
+		}
+		else {
+			C.printf(c'foo\n')
+		}
+	}
+}


### PR DESCRIPTION
Fix wrong code for switch stmt

```c
const int a = 0;

void f() 
{ 
    switch(a)
    {
    default:
    break;
    case 0:
        break;
    }
}
``` 

```
C to V translator 0.3.1
  translating tests/0.switch.c ... tests/0.switch.v:11:2: error: invalid expression: unexpected token `}`
    9 | fn f()  {
   10 |     match a {
   11 |     }
      |     ^
   12 |      else {
   13 |
```