### PR TITLE
fix code generated to multiple var declaration

### DIFF
--- a/src/c2v.v
+++ b/src/c2v.v
@@ -1403,6 +1403,9 @@ fn (mut c C2V) var_decl(mut decl_stmt Node) {
 			}
 			c.gen('${name} := ')
 			c.expr(expr)
+			if decl_stmt.inner.len > 1 {
+				c.gen('\n')
+			}
 		} else {
 			oldtyp := var_decl.ast_type.qualified
 			mut typ := typ_.name

--- a/tests/15.multi_var_decl.c
+++ b/tests/15.multi_var_decl.c
@@ -1,0 +1,3 @@
+int main() {
+int n, r, sum = 0, temp;
+}

--- a/tests/15.multi_var_decl.out
+++ b/tests/15.multi_var_decl.out
@@ -1,0 +1,9 @@
+[translated]
+module main
+
+fn main() {
+	n := 0
+	r := 0
+	sum := 0
+	temp := 0
+}


### PR DESCRIPTION
Fix var declaration ([V Issue  #17670](https://github.com/vlang/v/issues/17670))

```C
int main() {
int n, r, sum = 0, temp;
}
```

```V
[translated]
module main

fn main() {
	n := 0
	r := 0
	sum := 0
	temp := 0
}
```