### PR TITLE
Implement translation of opaque pointer types

### DIFF
--- a/src/c2v.v
+++ b/src/c2v.v
@@ -824,6 +824,13 @@ fn (mut c C2V) typedef_decl(node &Node) {
 	if node.name in builtin_type_names {
 		return
 	}
+
+	if typ.starts_with('struct ') && typ.ends_with(' *') {
+		// Opaque pointer, for example: typedef struct TSTexture_t *TSTexture;
+		c.genln('type ${alias_name} = voidptr')
+		return
+	}
+
 	if !typ.contains(alias_name) {
 		if typ.contains('(*)') {
 			tt := convert_type(typ)

--- a/tests/17.partial_struct.c
+++ b/tests/17.partial_struct.c
@@ -1,0 +1,1 @@
+typedef struct TSTexture_t *TSTexture;

--- a/tests/17.partial_struct.out
+++ b/tests/17.partial_struct.out
@@ -1,0 +1,4 @@
+[translated]
+module main
+
+type TSTexture = voidptr


### PR DESCRIPTION
Proprietary code commonly has opaque types declared in API headers instead of full declarations. This PR allows C2V to translate these types in V types (alias to voidptr)