### PR TITLE
Fix module name when generating wrapper

### DIFF
--- a/src/c2v.v
+++ b/src/c2v.v
@@ -228,7 +228,7 @@ fn (mut c2v C2V) add_file(ast_path string, outv string, c_file string) {
 
 	if c2v.is_wrapper {
 		// Generate v_wrapper.v in user's current directory
-		c2v.wrapper_module_name = os.dir(outv).after('/')
+		c2v.wrapper_module_name = os.dir(outv).all_after_last('/')
 		wrapper_path := c2v.outv
 		c2v.out_file = os.create(wrapper_path) or { panic('cant create file "${wrapper_path}" ') }
 	} else {
@@ -2117,6 +2117,11 @@ fn main() {
 	vprintln(os.args.str())
 	is_wrapper := os.args[1] == 'wrapper'
 	mut path := os.args.last()
+
+	if os.is_abs_path(path) == false {
+		path = os.abs_path(path)
+	}
+
 	if !os.exists(path) {
 		eprintln('"${path}" does not exist')
 		exit(1)

--- a/tests/run_tests.vsh
+++ b/tests/run_tests.vsh
@@ -54,12 +54,14 @@ fn start_testing_process(filter string, tests_dir string, c2v_dir string) {
 		exit(1)
 	}
 
-    os.chdir(tests_dir) or { panic('Failed to switch folder to tests folder for testing translation for relative paths - ${err}') }
+	os.chdir(tests_dir) or {
+		panic('Failed to switch folder to tests folder for testing translation for relative paths - ${err}')
+	}
 
-    if run_tests('.c', '', filter, '.', c2v_dir) == false
-    || run_tests('.h', 'wrapper', filter, '.', c2v_dir) == false {
-        exit(1)
-    }
+	if run_tests('.c', '', filter, '.', c2v_dir) == false
+		|| run_tests('.h', 'wrapper', filter, '.', c2v_dir) == false {
+		exit(1)
+	}
 }
 
 fn run_tests(test_file_extension string, c2v_command string, filter string, tests_dir string, c2v_dir string) bool {

--- a/tests/run_tests.vsh
+++ b/tests/run_tests.vsh
@@ -53,6 +53,13 @@ fn start_testing_process(filter string, tests_dir string, c2v_dir string) {
 		|| run_tests('.h', 'wrapper', filter, tests_dir, c2v_dir) == false {
 		exit(1)
 	}
+
+    os.chdir(tests_dir) or { panic('Failed to switch folder to tests folder for testing translation for relative paths - ${err}') }
+
+    if run_tests('.c', '', filter, '.', c2v_dir) == false
+    || run_tests('.h', 'wrapper', filter, '.', c2v_dir) == false {
+        exit(1)
+    }
 }
 
 fn run_tests(test_file_extension string, c2v_command string, filter string, tests_dir string, c2v_dir string) bool {


### PR DESCRIPTION
Before this PR, the module name was generated wrongly when generating a module for a single file, when the path to this file was relative