### PR TITLE
test: update `run_test.vsh`

### DIFF
--- a/tests/run_tests.vsh
+++ b/tests/run_tests.vsh
@@ -1,8 +1,20 @@
+#!/usr/bin/env -S v
+
 // Copyright (c) 2022 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by a GPL license that can
 // be found in the LICENSE file.
 import term
 import os
+
+const (
+	c2v_dir   = @VMODROOT
+	tests_dir = join_path(c2v_dir, 'tests')
+	exe_path  = join_path(c2v_dir, $if windows {
+		'c2v.exe'
+	} $else {
+		'c2v'
+	})
+)
 
 fn replace_file_extension(file_path string, old_extension string, new_extension string) string {
 	// NOTE: It can't be just `file_path.replace(old_extenstion, new_extension)`, because it will replace all occurencies of old_extenstion string.
@@ -23,22 +35,22 @@ fn try_process_filter_argument() string {
 	return ''
 }
 
-fn build_c2v(c2v_dir string) {
+fn build_c2v() {
 	chdir(c2v_dir) or {
-		println('Cannot change directory to ' + c2v_dir)
+		eprintln('Cannot change directory to ' + c2v_dir)
 		exit(1)
 	}
 
 	println('building c2v...')
 	c2v_build_command_result := execute('v -o c2v -experimental -w .')
 
-	if !exists(c2v_dir + '/c2v') || c2v_build_command_result.exit_code != 0 {
-		println('c2v compilation failed:')
-		println(c2v_build_command_result.output)
-		println('c2vdir="${c2v_dir}"')
+	if !exists(exe_path) || c2v_build_command_result.exit_code != 0 {
+		eprintln('c2v compilation failed:')
+		eprintln(c2v_build_command_result.output)
+		eprintln('c2vdir="${c2v_dir}"')
 
-		println(ls(c2v_dir) or {
-			println('Cannot list c2v directory')
+		eprintln(ls(c2v_dir) or {
+			eprintln('Cannot list c2v directory')
 			exit(1)
 		})
 
@@ -48,9 +60,8 @@ fn build_c2v(c2v_dir string) {
 	println('done')
 }
 
-fn start_testing_process(filter string, tests_dir string, c2v_dir string) {
-	if run_tests('.c', '', filter, tests_dir, c2v_dir) == false
-		|| run_tests('.h', 'wrapper', filter, tests_dir, c2v_dir) == false {
+fn start_testing_process(filter string) {
+	if run_tests('.c', '', filter) == false || run_tests('.h', 'wrapper', filter) == false {
 		exit(1)
 	}
 
@@ -58,14 +69,13 @@ fn start_testing_process(filter string, tests_dir string, c2v_dir string) {
 		panic('Failed to switch folder to tests folder for testing translation for relative paths - ${err}')
 	}
 
-	if run_tests('.c', '', filter, '.', c2v_dir) == false
-		|| run_tests('.h', 'wrapper', filter, '.', c2v_dir) == false {
+	if run_tests('.c', '', filter) == false || run_tests('.h', 'wrapper', filter) == false {
 		exit(1)
 	}
 }
 
-fn run_tests(test_file_extension string, c2v_command string, filter string, tests_dir string, c2v_dir string) bool {
-	mut files := get_test_files(tests_dir, test_file_extension).filter(it.all_after_last('/').starts_with('IGNORE_') == false)
+fn run_tests(test_file_extension string, c2v_opts string, filter string) bool {
+	mut files := get_test_files(test_file_extension).filter(it.all_after_last('/').starts_with('IGNORE_') == false)
 
 	files.sort()
 
@@ -89,10 +99,16 @@ fn run_tests(test_file_extension string, c2v_command string, filter string, test
 			return false
 		}
 
-		execute_c2v_command(c2v_command, file, c2v_dir)
+		c2v_cmd := '${exe_path} ${c2v_opts} ${file}'
+		c2v_res := execute(c2v_cmd)
+		if c2v_res.exit_code != 0 {
+			eprintln(c2v_res.output)
+			eprintln('command: ${c2v_cmd}')
+			return false
+		}
 
 		generated_file := try_get_generated_file(file, test_file_extension) or {
-			println(term.red('FAIL'))
+			eprintln(term.red('FAIL'))
 			return false
 		}
 
@@ -113,26 +129,23 @@ fn run_tests(test_file_extension string, c2v_command string, filter string, test
 	return true
 }
 
-fn get_test_files(tests_dir string, extension string) []string {
+fn get_test_files(extension string) []string {
 	return walk_ext(tests_dir, extension)
 }
 
 fn try_compile_test_file(file string) bool {
 	// Make sure the C test is a correct C program first
-	cmd := 'cc -c -w ${file} -o ${os.quoted_path(os.temp_dir())}/${os.file_name(file)}.o'
+	o_path := join_path(temp_dir(), file_name(file)) + '.o'
+	cmd := 'cc -c -w ${file} -o ${o_path}'
 	res := execute(cmd)
 
 	if res.exit_code != 0 {
-		eprintln(term.red('failed to compile C test `${file}`'))
+		eprintln('failed to compile C test `${file}`')
 		eprintln('command: ${cmd}')
 		return false
 	}
 
 	return true
-}
-
-fn execute_c2v_command(options string, file string, c2v_dir string) {
-	system('${c2v_dir}/c2v ' + options + ' ${file} > /dev/null')
 }
 
 fn try_get_generated_file(file string, test_file_extension string) !string {
@@ -161,37 +174,34 @@ fn get_result_file_content(file string, test_file_extension string) string {
 }
 
 fn print_test_fail_details(expected string, got string) {
-	println(term.red('\nFAIL'))
-	println('expected:')
-	println(expected)
-	println('\n===got:')
-	println(got)
+	eprintln(term.red('\nFAIL'))
+	eprintln('expected:')
+	eprintln(expected)
+	eprintln('\n===got:')
+	eprintln(got)
 
-	println('\n====diff=====')
-	expected_file_form := temp_dir() + '/expected.txt'
-	got_file_form := temp_dir() + '/got.txt'
+	eprintln('\n====diff=====')
+	expected_file_form := join_path(temp_dir(), 'expected.txt')
+	got_file_form := join_path(temp_dir(), 'got.txt')
 
-	write_file(expected_file_form, expected) or { println('Cannot write expected file') }
-	write_file(got_file_form, got) or { println('Cannot write got file') }
+	write_file(expected_file_form, expected) or { eprintln('Cannot write expected file') }
+	write_file(got_file_form, got) or { eprintln('Cannot write got file') }
 
 	diff := execute('diff -u ${expected_file_form} ${got_file_form}')
-	println(diff.output)
+	eprintln(diff.output)
 
-	println('\n')
+	eprintln('\n')
 }
 
 fn do_post_test_cleanup(generated_file string) {
 	os.rm(generated_file) or {}
 }
 
-exe := executable()
-tests_dir := dir(exe)
-c2v_dir := dir(tests_dir)
 mut filter := ''
 
 if os.args.len > 1 {
 	filter = try_process_filter_argument()
 }
 
-build_c2v(c2v_dir)
-start_testing_process(filter, tests_dir, c2v_dir)
+build_c2v()
+start_testing_process(filter)


### PR DESCRIPTION
Simplifies the script and improves platform independence. c2v currently produces different outcome on windows, so the script will still fail on windows. But in general this improvement creates the base for windows compatibility.

- Uses consts for c2v and test path instead of passing them as args to simplify the logic.
- eprint instead of prints for error output
- join_path to join file paths

