### PR TITLE
fix missing `as` as keyword

### DIFF
--- a/src/c2v.v
+++ b/src/c2v.v
@@ -13,7 +13,7 @@ const version = '0.4.0'
 
 // V keywords, that are not keywords in C:
 const v_keywords = ['go', 'type', 'true', 'false', 'module', 'byte', 'in', 'none', 'map', 'string',
-	'spawn', 'shared', 'select']
+	'spawn', 'shared', 'select', 'as']
 
 // libc fn definitions that have to be skipped (V already knows about them):
 const builtin_fn_names = ['fopen', 'puts', 'fflush', 'printf', 'memset', 'atoi', 'memcpy', 'remove',


### PR DESCRIPTION
Fix #118
