### PR TITLE
fix: update v keywords list (fix #191)

### DIFF
--- a/src/c2v.v
+++ b/src/c2v.v
@@ -13,10 +13,12 @@ import datatypes
 const version = '0.4.1'
 
 // V keywords, that are not keywords in C:
-const v_keywords = ['as', 'asm', 'assert', 'atomic', 'defer', 'false', 'fn', 'go', 'implements',
-	'import', 'in', 'interface', 'is', 'isreftype', 'lock', 'match', 'map', 'module', 'mut', 'none',
-	'or', 'pub', 'rlock', 'select', 'shared', 'spawn', 'string', 'true', 'type', 'typeof', 'unsafe',
-	'__global', '__offsetof']
+const v_keywords = ['!in', '!is', '__global', '__offsetof', 'as', 'asm', 'assert', 'atomic', 'bool',
+	'byte', 'defer', 'dump', 'f32', 'f64', 'false', 'fn', 'go', 'i16', 'i64', 'i8', 'implements',
+	'import', 'in', 'interface', 'is', 'isize', 'isreftype', 'lock', 'map', 'match', 'module',
+	'mut', 'nil', 'none', 'or', 'pub', 'rlock', 'rune', 'select', 'shared', 'spawn', 'string',
+	'struct', 'thread', 'true', 'type', 'typeof', 'u16', 'u32', 'u64', 'u8', 'unsafe', 'usize',
+	'voidptr']
 
 // libc fn definitions that have to be skipped (V already knows about them):
 const builtin_fn_names = ['fopen', 'puts', 'fflush', 'getline', 'printf', 'memset', 'atoi', 'memcpy',

--- a/src/c2v.v
+++ b/src/c2v.v
@@ -13,7 +13,11 @@ import datatypes
 const version = '0.4.1'
 
 // V keywords, that are not keywords in C:
-const v_keywords = ['as', 'asm', 'assert', 'atomic', 'break', 'const', 'continue', 'defer', 'else', 'enum', 'false', 'fn', 'for', 'go', 'goto', 'if', 'implements', 'import', 'in', 'interface', 'is', 'isreftype', 'lock', 'match', 'module', 'mut', 'none', 'or', 'pub', 'return', 'rlock', 'select', 'shared', 'sizeof', 'spawn', 'static', 'struct', 'true', 'type', 'typeof', 'union', 'unsafe', 'volatile', '__global', '__offsetof']
+const v_keywords = ['as', 'asm', 'assert', 'atomic', 'break', 'const', 'continue', 'defer', 'else',
+	'enum', 'false', 'fn', 'for', 'go', 'goto', 'if', 'implements', 'import', 'in', 'interface',
+	'is', 'isreftype', 'lock', 'match', 'module', 'mut', 'none', 'or', 'pub', 'return', 'rlock',
+	'select', 'shared', 'sizeof', 'spawn', 'static', 'struct', 'true', 'type', 'typeof', 'union',
+	'unsafe', 'volatile', '__global', '__offsetof']
 
 // libc fn definitions that have to be skipped (V already knows about them):
 const builtin_fn_names = ['fopen', 'puts', 'fflush', 'getline', 'printf', 'memset', 'atoi', 'memcpy',

--- a/src/c2v.v
+++ b/src/c2v.v
@@ -14,11 +14,10 @@ const version = '0.4.1'
 
 // V keywords, that are not keywords in C:
 const v_keywords = ['!in', '!is', '__global', '__offsetof', 'as', 'asm', 'assert', 'atomic', 'bool',
-	'byte', 'defer', 'dump', 'f32', 'f64', 'false', 'fn', 'go', 'i16', 'i64', 'i8', 'implements',
-	'import', 'in', 'interface', 'is', 'isize', 'isreftype', 'lock', 'map', 'match', 'module',
-	'mut', 'nil', 'none', 'or', 'pub', 'rlock', 'rune', 'select', 'shared', 'spawn', 'string',
-	'struct', 'thread', 'true', 'type', 'typeof', 'u16', 'u32', 'u64', 'u8', 'unsafe', 'usize',
-	'voidptr']
+	'byte', 'defer', 'dump', 'false', 'fn', 'go', 'implements', 'import', 'in', 'interface', 'is',
+	'isize', 'isreftype', 'lock', 'map', 'match', 'module', 'mut', 'nil', 'none', 'or', 'pub',
+	'rlock', 'rune', 'select', 'shared', 'spawn', 'string', 'struct', 'thread', 'true', 'type',
+	'typeof', 'unsafe', 'usize', 'voidptr']
 
 // libc fn definitions that have to be skipped (V already knows about them):
 const builtin_fn_names = ['fopen', 'puts', 'fflush', 'getline', 'printf', 'memset', 'atoi', 'memcpy',

--- a/src/c2v.v
+++ b/src/c2v.v
@@ -13,8 +13,7 @@ import datatypes
 const version = '0.4.1'
 
 // V keywords, that are not keywords in C:
-const v_keywords = ['go', 'type', 'true', 'false', 'module', 'byte', 'in', 'none', 'map', 'string',
-	'spawn', 'shared', 'select', 'as', 'fn']
+const v_keywords = ['as', 'asm', 'assert', 'atomic', 'break', 'const', 'continue', 'defer', 'else', 'enum', 'false', 'fn', 'for', 'go', 'goto', 'if', 'implements', 'import', 'in', 'interface', 'is', 'isreftype', 'lock', 'match', 'module', 'mut', 'none', 'or', 'pub', 'return', 'rlock', 'select', 'shared', 'sizeof', 'spawn', 'static', 'struct', 'true', 'type', 'typeof', 'union', 'unsafe', 'volatile', '__global', '__offsetof']
 
 // libc fn definitions that have to be skipped (V already knows about them):
 const builtin_fn_names = ['fopen', 'puts', 'fflush', 'getline', 'printf', 'memset', 'atoi', 'memcpy',

--- a/src/c2v.v
+++ b/src/c2v.v
@@ -13,11 +13,10 @@ import datatypes
 const version = '0.4.1'
 
 // V keywords, that are not keywords in C:
-const v_keywords = ['as', 'asm', 'assert', 'atomic', 'break', 'const', 'continue', 'defer', 'else',
-	'enum', 'false', 'fn', 'for', 'go', 'goto', 'if', 'implements', 'import', 'in', 'interface',
-	'is', 'isreftype', 'lock', 'match', 'module', 'mut', 'none', 'or', 'pub', 'return', 'rlock',
-	'select', 'shared', 'sizeof', 'spawn', 'static', 'struct', 'true', 'type', 'typeof', 'union',
-	'unsafe', 'volatile', '__global', '__offsetof']
+const v_keywords = ['as', 'asm', 'assert', 'atomic', 'defer', 'false', 'fn', 'go', 'implements',
+	'import', 'in', 'interface', 'is', 'isreftype', 'lock', 'match', 'map', 'module', 'mut', 'none',
+	'or', 'pub', 'rlock', 'select', 'shared', 'spawn', 'string', 'true', 'type', 'typeof', 'unsafe',
+	'__global', '__offsetof']
 
 // libc fn definitions that have to be skipped (V already knows about them):
 const builtin_fn_names = ['fopen', 'puts', 'fflush', 'getline', 'printf', 'memset', 'atoi', 'memcpy',

--- a/src/c2v.v
+++ b/src/c2v.v
@@ -13,11 +13,11 @@ import datatypes
 const version = '0.4.1'
 
 // V keywords, that are not keywords in C:
-const v_keywords = ['!in', '!is', '__global', '__offsetof', 'as', 'asm', 'assert', 'atomic', 'bool',
-	'byte', 'defer', 'dump', 'false', 'fn', 'go', 'implements', 'import', 'in', 'interface', 'is',
-	'isize', 'isreftype', 'lock', 'map', 'match', 'module', 'mut', 'nil', 'none', 'or', 'pub',
-	'rlock', 'rune', 'select', 'shared', 'spawn', 'string', 'struct', 'thread', 'true', 'type',
-	'typeof', 'unsafe', 'usize', 'voidptr']
+const v_keywords = ['__global', '__offsetof', 'as', 'asm', 'assert', 'atomic', 'bool', 'byte',
+	'defer', 'dump', 'false', 'fn', 'go', 'implements', 'import', 'in', 'interface', 'is', 'isize',
+	'isreftype', 'lock', 'map', 'match', 'module', 'mut', 'nil', 'none', 'or', 'pub', 'rlock',
+	'rune', 'select', 'shared', 'spawn', 'string', 'struct', 'thread', 'true', 'type', 'typeof',
+	'unsafe', 'usize', 'voidptr']
 
 // libc fn definitions that have to be skipped (V already knows about them):
 const builtin_fn_names = ['fopen', 'puts', 'fflush', 'getline', 'printf', 'memset', 'atoi', 'memcpy',


### PR DESCRIPTION
Due to missing keywords some translated code would include v keywords as variable names causing invalid translated code. I have added all keywords listed in [the docs](https://docs.vlang.io/appendix-i-keywords.html). This also fixes my issue #191.